### PR TITLE
Enable setting log_path from env variables

### DIFF
--- a/dynamicmacros.py
+++ b/dynamicmacros.py
@@ -13,8 +13,8 @@ import jinja2
 from .gcode_macro import TemplateWrapper
 
 # Define the path to the configuration files
-config_path = Path(os.path.expanduser('~')) / 'printer_data' / 'config'
-log_path = Path(os.path.expanduser('~')) / 'DynamicMacros-logs' / 'DynamicMacros.log'
+config_path = os.environ['DY_MAC_CONFIG']
+log_path = os.environ['DY_MAC_LOGS']
 
 os.makedirs(log_path.parent, exist_ok=True)
 

--- a/dynamicmacros.py
+++ b/dynamicmacros.py
@@ -13,10 +13,16 @@ import jinja2
 from .gcode_macro import TemplateWrapper
 
 # Define the path to the configuration files
-config_path = os.environ['DY_MAC_CONFIG']
-log_path = os.environ['DY_MAC_LOGS']
+if os.getenv("DYNAMIC_MACRO_CONFIG") is not None:
+    config_path = os.getenv("DYNAMIC_MACRO_CONFIG")
+else:
+    config_path = Path(os.path.expanduser('~')) / 'printer_data' / 'config'
 
-# os.makedirs(log_path.parent, exist_ok=True)
+if os.getenv("DYNAMIC_MACRO_LOGS") is not None:
+    log_path = os.getenv("DYNAMIC_MACRO_LOGS")
+else:
+    log_path = Path(os.path.expanduser('~')) / 'DynamicMacros-logs' / 'DynamicMacros.log'
+    os.makedirs(log_path.parent, exist_ok=True)
 
 class MacroConfigParser:
     def __init__(self, printer, delimeter):

--- a/dynamicmacros.py
+++ b/dynamicmacros.py
@@ -16,7 +16,7 @@ from .gcode_macro import TemplateWrapper
 config_path = os.environ['DY_MAC_CONFIG']
 log_path = os.environ['DY_MAC_LOGS']
 
-os.makedirs(log_path.parent, exist_ok=True)
+# os.makedirs(log_path.parent, exist_ok=True)
 
 class MacroConfigParser:
     def __init__(self, printer, delimeter):

--- a/dynamicmacros.py
+++ b/dynamicmacros.py
@@ -13,10 +13,7 @@ import jinja2
 from .gcode_macro import TemplateWrapper
 
 # Define the path to the configuration files
-if os.getenv("DYNAMIC_MACRO_CONFIG") is not None:
-    config_path = os.getenv("DYNAMIC_MACRO_CONFIG")
-else:
-    config_path = Path(os.path.expanduser('~')) / 'printer_data' / 'config'
+config_path = Path(os.path.expanduser('~')) / 'printer_data' / 'config'
 
 if os.getenv("DYNAMIC_MACRO_LOGS") is not None:
     log_path = os.getenv("DYNAMIC_MACRO_LOGS")


### PR DESCRIPTION
Enables setting the config path and log path from environment variables, useful when using a non standard klipper install directory particularly in container environments.
Defaults to original values if unset.